### PR TITLE
Ensuring class is subclass of TimberPost

### DIFF
--- a/lib/timber-post-getter.php
+++ b/lib/timber-post-getter.php
@@ -95,7 +95,7 @@ class TimberPostGetter {
 		}
 		if (is_array($arg)) {
 			foreach ($arg as $item) {
-				if (is_string($item) && class_exists($item)) {
+				if (is_string($item) && (class_exists($item) && is_subclass_of($item, 'TimberPost'))) {
 					return true;
 				}
 			}


### PR DESCRIPTION
**Issue**

Let's say you have a custom post type called `job` and you have a file `inc/job.php` that contains a `class Job {}`. This class just contains some helper functions for your `job` post type, filtering etc.

With all that in mind, if you try and then do `Timber::get_posts(array('post_type' => 'job'))` it will not work and return the page you are on, rather than the jobs.

**Solution**

Add an extra check to make sure a class extends `TimberPost` before using the class (as the doc explains).

**Impact**

This will break (incorrect) implementations that uses classes without extending `TimberPost`.

**Usage**

No change
